### PR TITLE
Fix command interpreter parameter

### DIFF
--- a/nexsan.sh
+++ b/nexsan.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/expect -f
+#!/usr/bin/expect -c
 set timeout 5
 set TARGET_HOSTIP [lindex $argv 0]
 set TARGET_USERNAME [lindex $argv 1]


### PR DESCRIPTION
The expect command interpreter should have the parameter -c, not -f, as that would imply a file.